### PR TITLE
fix: diagnostic validator now type checks if value is a table

### DIFF
--- a/lua/lsp_lines/render.lua
+++ b/lua/lsp_lines/render.lua
@@ -50,8 +50,8 @@ function M.show(namespace, bufnr, diagnostics, opts, source)
     bufnr = { bufnr, "n" },
     diagnostics = {
       diagnostics,
-      vim.tbl_islist,
-      "a list of diagnostics",
+      function(v) return type(v) == "table" end,
+      "a list of diagnostics"
     },
     opts = { opts, "t", true },
   })


### PR DESCRIPTION
Previously would return invalid validator: nil due to vim.tbl_islist

Resolves this:
```
E5108: Lua: .../share/nvim/lazy/lsp_lines.nvim/lua/lsp_lines/render.lua:48: invalid validator: nil
stack traceback:
        [C]: in function 'error'
        vim/_core/shared:1305: in function 'validate'
        .../share/nvim/lazy/lsp_lines.nvim/lua/lsp_lines/render.lua:48: in function 'show'
        ...al/share/nvim/lazy/lsp_lines.nvim/lua/lsp_lines/init.lua:45: in function 'show'
        ...t/usr/share/nvim/runtime/lua/vim/diagnostic/_display.lua:187: in function 'show'
        ...ot/usr/share/nvim/runtime/lua/vim/diagnostic/_config.lua:151: in function 'config'
        ...al/share/nvim/lazy/lsp_lines.nvim/lua/lsp_lines/init.lua:63: in function <...al/share/nvim/lazy/lsp_lines.nvim/lua/lsp_lines/init.lua:61>
```

nvim version:
```
❯ nvim -v
NVIM v0.13.0-dev-606+g3600d1c13c
Build type: RelWithDebInfo
LuaJIT 2.1.1774896198
Run "nvim -V1 -v" for more info
```
